### PR TITLE
The "Get Involved" Email Blast

### DIFF
--- a/Communications/21_12_get_involved_member_comms.md
+++ b/Communications/21_12_get_involved_member_comms.md
@@ -81,9 +81,9 @@ The sponsorship committee is here to help engage and grow corporate sponsors, fo
 - You help grow the .NET community by promoting & increasing corporate membership.
 - You come up with ways to increase corporate engagement in the .NET open-source community as a whole.
 
-**TODO MEETING SCHEDULE**. If you're passionate about larger corporations giving back to the .NET community, and want to come up with ways to attract and retain corporate sponsors; this is the committee for you!
+This committee meets every third Wednesday of the month, usually at 13:00 ET for up to an hour. If you're passionate about larger corporations giving back to the .NET community, and want to come up with ways to attract and retain corporate sponsors; this is the committee for you!
 
-**TODO HOW TO JOIN**
+To get involved, [send an email](mailto:javier.lozano@dotnetfoundation.org) to [@jglozano](https://github.com/jglozano) (the chairperson). 
 
 ### [Membership Committee](https://github.com/dotnet-foundation/wg-membership)
 

--- a/Communications/21_12_get_involved_member_comms.md
+++ b/Communications/21_12_get_involved_member_comms.md
@@ -74,6 +74,17 @@ This committee meets every second and fourth Wednesday of the month, usually at 
 
 To get involved, [request to join the education team on GitHub](https://github.com/orgs/dotnet-foundation/teams/education/members) using the "Request to join" button. 
 
+### [Sponsorship Committee](https://github.com/dotnet-foundation/wg-corporate-relations)
+
+The sponsorship committee is here to help engage and grow corporate sponsors, focused on initiatives that help provide sponsors that help fund the operation of the .NET Foundation with opportunities to engage and inform the .NET community. As part of this committee:
+- You work to enhance coprorate sponsorship to provide value to corporations sponsoring the .NET Foundation.
+- You help grow the .NET community by promoting & increasing corporate membership.
+- You come up with ways to increase corporate engagement in the .NET open-source community as a whole.
+
+**TODO MEETING SCHEDULE**. If you're passionate about larger corporations giving back to the .NET community, and want to come up with ways to attract and retain corporate sponsors; this is the committee for you!
+
+**TODO HOW TO JOIN**
+
 ### [Membership Committee](https://github.com/dotnet-foundation/wg-membership)
 
 The Membership Committee reviews incoming member applications against the eligibility criteria, which the committee also periodically reviews and amends as needed. As a member of this committee:

--- a/Communications/21_12_get_involved_member_comms.md
+++ b/Communications/21_12_get_involved_member_comms.md
@@ -1,0 +1,86 @@
+# The "Get Involved" Email Blast
+
+This is an email put together for all .NET Foundation members to raise awareness of how they can help out in shaping the .NET Foundation, and hopefully encourage "passive" members to become more active within the .NET Foundation.
+
+- To: All Members (Mailing List)
+- Subject: Help build your .NET Foundation
+
+---
+
+In the .NET Foundation, people are key to our success. We are passionate about empowering projects, communities, and individuals to thrive and evangelise within the .NET ecosystem; but this only starts with members who are keen to do so.
+
+You're here because you're passionate about .NET, and have made substantial contributions to surrounding projects and communities. The .NET Foundation is here to help you take that passion further, and shape the .NET community as a whole to make it better for everyone. So whether you maintain a .NET project, or have contributed to one; whether you write code, manage a community, or just about anything else; we're glad you're here and want to build the .NET Foundation and the .NET community you all want to see.
+
+The best way to get started? Get involved in one of the .NET Foundation committees!
+
+One of the benefits of being a .NET Foundation member is being able to partake and directly help with the many committees that drive the .NET Foundation and help further its particular goals. Anyone can join a committee and help out, and you can be a member of as many committees as you'd like. This is your .NET Foundation, and we'd love your help to build it!
+
+Below is a summary of the various committees within the .NET Foundation. If there's anything you're particularly passionate about, get involved and let them know!
+
+## The Committees
+
+### [Projects Committee](https://github.com/dotnet-foundation/projects)
+
+The Projects Committee reviews incoming project applications against the eligibility criteria, which the committee also periodically reviews and amends as needed. As a member of this committee:
+- You advise the Board on which projects are eligible and should be onboarded.
+- You discuss with other committee members to ensure the eligibility criteria stays up-to-date and reflects the .NET Foundation's goals.
+- You work with maintainers of eligible projects to onboard into the .NET Foundation, and keep an eye on those that aren't eligible to occasionally re-review to see if they become eligible over time.
+
+This committee meets every second Thursday of the month. If you want to help us define what it means to be a .NET Foundation project, as well as help us figure out which projects to onboard into the Foundation's diverse roster; this is the committee for you!
+
+To get involved, [open a discussion in the Projects Commitee section of dotnet-foundation/Home](https://github.com/dotnet-foundation/Home/discussions/categories/projects-committee) and include [@sbwalker](https://github.com/sbwalker) (the chairperson) on the discussion.
+
+### [Maintainers Committee](https://github.com/dotnet-foundation/wg-maintainers)
+
+The Maintainers Committee acts as a "sounding board" for the .NET Foundation for changes that affect projects within the.NET Foundation, as well as the precedent the Foundation sets for projects within the .NET ecosystem as a whole. As a member of this committee:
+- You advise the Board on what support maintainers of projects, members and non-members alike, need from the .NET Foundation to thrive.
+- You voice your opinion on upcoming planned changes on the .NET Foundation's project management and operations to the Board.
+- You communicate and work with other like-minded maintainers within the committee to support each other and ensure everyone's on the same page.
+
+This committee meets every second Wednesday of the month, usually at 21:00 UTC for up to an hour. If you want to help us ensure maintainers have all the support they need to maintain their projects and do what they do best, this is the committee for you!
+
+To get involved, [open an issue on the Maintainers Committee repo](https://github.com/dotnet-foundation/wg-maintainers/issues/new?assignees=rprouse%2Cdevlead&labels=membership&template=membership.md) and include [@devlead](https://github.com/devlead) & [@rprouse](https://github.com/rprouse) (chairpersons) on the issue.
+
+### [Outreach Committee](https://github.com/dotnet-foundation/wg-outreach)
+
+The Outreach Committee is here to welcome developers of all backgrounds, education, and technology experience into the .NET ecosystem, and help members organize and evangelize with your own .NET communities, opportunities, and events. As a member of this committee:
+- You discuss ways to engage & empower communities, including those underrepresented in the industry as a whole, to contribute & thrive within the .NET ecosystem.
+- You help encourage new developers to build with .NET and join the .NET ecosystem & community.
+- You assist event organizers with evangelism and proliferating the growth of the .NET ecosystem & community.
+
+This committee meets every second Tuesday of the month, usually at 15:00 ET for up to an hour. If you're passionate about finding ways to encourage people to build their applications with .NET, this is the committee for you!
+
+To get involved, [open an issue on the Outreach Committee repo](https://github.com/dotnet-foundation/wg-outreach/issues/new?assignees=shawnwildermuth) and include [@shawnwildermuth](https://github.com/shawnwildermuth) (the chairperson) on the issue.
+
+### [Marketing Committee](https://github.com/dotnet-foundation/wg-marketing)
+
+The Marketing Committee is here to spread the word about .NET and its open ecosystem, supporting the community and project initiatives, driving awareness about the .NET Foundation and its openness, and encouraging new members to join the .NET Foundation. As a member of this committee:
+- You work to create consistent, powerful storytelling to increase share of conversation and establish industry relevance for the .NET Foundation.
+- You help the committee and the .NET Foundation as a whole foster an open, healthy .NET community.
+- You come up with new ways to drive .NET Foundation membership and engagement.
+
+This committee meets every first Thursday of the month, usually at 9:00 PT. If you're passionate about encouraging people to get involved with the .NET community and join the .NET Foundation, this is the committee for you!
+
+To get involved, [open a discussion in the Marketing Committee section of dotnet-foundation/Home](https://github.com/dotnet-foundation/Home/discussions/categories/marketing-committee) and include [@isaacrlevin](https://github.com/isaacrlevin) (the chairperson) on the discussion.
+
+### [Education Committee](https://github.com/dotnet-foundation/wg-education)
+
+The education committee is here to develop, sponsor, and provide educational opportunities for the .NET community. As a member of this committee:
+- You create open-source educational content for the .NET community.
+- You work to empower those who are underrepresented and underserved in the community.
+- You help the committee partner and run educational opportunities that train new and existing .NET developers.
+
+This committee meets every second and fourth Wednesday of the month, usually at 11:00 ET for up to an hour. If you're passionate about training up the .NET community with engaging educational content and initiatives, this is the committee for you!
+
+To get involved, [request to join the education team on GitHub](https://github.com/orgs/dotnet-foundation/teams/education/members) using the "Request to join" button. 
+
+### [Membership Committee](https://github.com/dotnet-foundation/wg-membership)
+
+The Membership Committee reviews incoming member applications against the eligibility criteria, which the committee also periodically reviews and amends as needed. As a member of this committee:
+- You evaluate new membership applications.
+- You discuss with other committee members to ensure the eligibility criteria stays up-to-date and reflects the current state of the .NET Foundation.
+- You raise issues with the current membership offering, and come up with new ideas on how the membership offering could be enhanced.
+
+This committee meets every first and third Tuesday of the month, usually at 13:30 UTC. If you want to help us define what it means to be a .NET Foundation member, as well as help us figure out the criteria for new members, this is the committee for you!
+
+To get involved, [open an issue on the Membership Committee repo](https://github.com/dotnet-foundation/wg-membership/issues/new?assignees=billwagner&labels=membership&template=membership_request) and include [@billwagner](https://github.com/billwagner) (the chairperson) on the issue.

--- a/Communications/21_12_get_involved_member_comms.md
+++ b/Communications/21_12_get_involved_member_comms.md
@@ -26,9 +26,7 @@ The Projects Committee reviews incoming project applications against the eligibi
 - You discuss with other committee members to ensure the eligibility criteria stays up-to-date and reflects the .NET Foundation's goals.
 - You work with maintainers of eligible projects to onboard into the .NET Foundation, and keep an eye on those that aren't eligible to occasionally re-review to see if they become eligible over time.
 
-This committee meets every second Thursday of the month. If you want to help us define what it means to be a .NET Foundation project, as well as help us figure out which projects to onboard into the Foundation's diverse roster; this is the committee for you!
-
-To get involved, [open a discussion in the Projects Commitee section of dotnet-foundation/Home](https://github.com/dotnet-foundation/Home/discussions/categories/projects-committee) and include [@sbwalker](https://github.com/sbwalker) (the chairperson) on the discussion.
+The meeting cadence for this commitee & how to get involved is uncertain at this time. Watch this space if this is the committee for you!
 
 ### [Maintainers Committee](https://github.com/dotnet-foundation/wg-maintainers)
 
@@ -70,9 +68,7 @@ The education committee is here to develop, sponsor, and provide educational opp
 - You work to empower those who are underrepresented and underserved in the community.
 - You help the committee partner and run educational opportunities that train new and existing .NET developers.
 
-This committee meets every second and fourth Wednesday of the month, usually at 11:00 ET for up to an hour. If you're passionate about training up the .NET community with engaging educational content and initiatives, this is the committee for you!
-
-To get involved, [request to join the education team on GitHub](https://github.com/orgs/dotnet-foundation/teams/education/members) using the "Request to join" button. 
+The meeting cadence for this commitee & how to get involved is uncertain at this time. Watch this space if this is the committee for you!
 
 ### [Sponsorship Committee](https://github.com/dotnet-foundation/wg-corporate-relations)
 


### PR DESCRIPTION
This is an email put together for all .NET Foundation members to raise awareness of how they can help out in shaping the .NET Foundation, and hopefully encourage "passive" members to become more active within the .NET Foundation.

The opening of the email describes how the .NET Foundation operates and what it means to be a member, as well as how members can get involved (i.e. committees). This is meant to be the "persuasive" bit of the email, so let me know if there's any way I can improve this.

After that, the email describes each of the active committees. I've structured this in terms of what a committee member could be doing (i.e. using "you" a lot, sort of like a job description) to hopefully make it obvious what the committee is doing.

For committees that didn't have an obvious joining mechanism, I've linked them to the discussions repo. Otherwise, the "how to join" bit is copied and pasted from the working group repos, as with the meeting dates and other parts of the content.

The committee are in order from the most project-centric committees to the most people-centric committees, so the committees most likely to be relevant depending on a particular member's interests are bundled close together.

Let me know what you think.